### PR TITLE
Fix mekabow autofire not working properly when attack speed too high

### DIFF
--- a/src/main/java/meranha/mekaweapons/items/ItemMekaBow.java
+++ b/src/main/java/meranha/mekaweapons/items/ItemMekaBow.java
@@ -71,7 +71,7 @@ public class ItemMekaBow extends BowItem implements IModuleContainerItem {
     }
 
     public void onUseTick(@Nonnull Level world, @Nonnull LivingEntity player, @Nonnull ItemStack stack, int timeLeft) {
-        if (isModuleEnabled(stack, MekaWeapons.AUTOFIRE_UNIT) && getUseDuration(stack, player) - timeLeft == getUseTick(stack)) {
+        if (isModuleEnabled(stack, MekaWeapons.AUTOFIRE_UNIT) && getUseDuration(stack, player) - timeLeft <= getUseTick(stack)) {
             player.stopUsingItem();
             stack.releaseUsing(world, player, 0);
             player.startUsingItem(player.getUsedItemHand());


### PR DESCRIPTION
The Meka Bow's autofire unit does not work when player's attack speed is vastly increased. To replicate: Equip God's Crown from Reliquary mod (+120% all stats), Meka Bow's autofire stops working properly. (MC version 1.19.2, but probably happens on other versions too). Bug can probably be replicated with any other way to increase attack speed.

Changed firing check from == to <= as a hotfix.