### PR TITLE
Fixed that damage is not increased when only one attack amplification module is installed

### DIFF
--- a/src/main/java/meranha/mekaweapons/items/ItemMekaBow.java
+++ b/src/main/java/meranha/mekaweapons/items/ItemMekaBow.java
@@ -111,8 +111,8 @@ public class ItemMekaBow extends BowItem implements IModuleContainerItem {
 
     public int getDamage(@Nonnull ItemStack stack) {
         IModule<ModuleAttackAmplificationUnit> attackAmplificationUnit = getEnabledModule(stack, MekanismModules.ATTACK_AMPLIFICATION_UNIT);
-        int installedModules = (attackAmplificationUnit != null) ? attackAmplificationUnit.getInstalledCount() : 1;
-        return MekaWeapons.general.mekaBowBaseDamage.get() * (installedModules);
+        int installedModules = (attackAmplificationUnit != null) ? attackAmplificationUnit.getInstalledCount() : 0;
+        return MekaWeapons.general.mekaBowBaseDamage.get() * (installedModules + 1);
     }
 
     @Override

--- a/src/main/java/meranha/mekaweapons/items/ItemMekaTana.java
+++ b/src/main/java/meranha/mekaweapons/items/ItemMekaTana.java
@@ -64,9 +64,9 @@ public class ItemMekaTana extends ItemEnergized implements IModuleContainerItem 
     @Override
     public boolean hurtEnemy(@NotNull ItemStack stack, @NotNull LivingEntity target, @NotNull LivingEntity attacker) {
         IModule<ModuleAttackAmplificationUnit> attackAmplificationUnit = getEnabledModule(stack, MekanismModules.ATTACK_AMPLIFICATION_UNIT);
-        int installedModules = (attackAmplificationUnit != null) ? attackAmplificationUnit.getInstalledCount() : 1;
+        int installedModules = (attackAmplificationUnit != null) ? attackAmplificationUnit.getInstalledCount() : 0;
         int baseDamage = MekaWeapons.general.mekaTanaBaseDamage.get();
-        int totalDamage = baseDamage * (installedModules);
+        int totalDamage = baseDamage * (installedModules + 1);
 
         IEnergyContainer energyContainer = StorageUtils.getEnergyContainer(stack, 0);
         if (totalDamage > baseDamage && energyContainer != null && attacker instanceof Player player && !player.isCreative()) {


### PR DESCRIPTION
I was wondering how much damage these weapons do. I read the code and noticed (probably) a small bug in where having only one attack amplification unit installed results in the same max damage as with no modules at all. I say probably because I did not run the code yet. Maybe you already thought of this and fixed it in some other way.

Either way thanks for the cool mod!