### PR TITLE
Added Item Exist NeoForge Conditions at all recipe

### DIFF
--- a/src/main/resources/data/mekaweapons/recipe/bow_limb.json
+++ b/src/main/resources/data/mekaweapons/recipe/bow_limb.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:bow_limb"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:bow_limb"

--- a/src/main/resources/data/mekaweapons/recipe/bow_riser.json
+++ b/src/main/resources/data/mekaweapons/recipe/bow_riser.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:bow_limb"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:bow_riser"

--- a/src/main/resources/data/mekaweapons/recipe/katana_blade.json
+++ b/src/main/resources/data/mekaweapons/recipe/katana_blade.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:katana_blade"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:katana_blade"

--- a/src/main/resources/data/mekaweapons/recipe/magnetizer.json
+++ b/src/main/resources/data/mekaweapons/recipe/magnetizer.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:magnetizer"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:magnetizer"

--- a/src/main/resources/data/mekaweapons/recipe/meka_bow.json
+++ b/src/main/resources/data/mekaweapons/recipe/meka_bow.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:meka_bow"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:meka_bow"

--- a/src/main/resources/data/mekaweapons/recipe/meka_tana.json
+++ b/src/main/resources/data/mekaweapons/recipe/meka_tana.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:meka_tana"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:meka_tana"

--- a/src/main/resources/data/mekaweapons/recipe/module_arrowenergy_unit.json
+++ b/src/main/resources/data/mekaweapons/recipe/module_arrowenergy_unit.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:module_arrowenergy_unit"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:module_arrowenergy_unit"

--- a/src/main/resources/data/mekaweapons/recipe/module_arrowvelocity_unit.json
+++ b/src/main/resources/data/mekaweapons/recipe/module_arrowvelocity_unit.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:module_arrowvelocity_unit"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:module_arrowvelocity_unit"

--- a/src/main/resources/data/mekaweapons/recipe/module_attackamplification_unit.json
+++ b/src/main/resources/data/mekaweapons/recipe/module_attackamplification_unit.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:module_attackamplification_unit"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:module_attackamplification_unit"

--- a/src/main/resources/data/mekaweapons/recipe/module_attackamplification_unit_reverse.json
+++ b/src/main/resources/data/mekaweapons/recipe/module_attackamplification_unit_reverse.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:module_attack_amplification_unit"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekanism:module_attack_amplification_unit"

--- a/src/main/resources/data/mekaweapons/recipe/module_autofire_unit.json
+++ b/src/main/resources/data/mekaweapons/recipe/module_autofire_unit.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:module_autofire_unit"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:module_autofire_unit"

--- a/src/main/resources/data/mekaweapons/recipe/module_drawspeed_unit.json
+++ b/src/main/resources/data/mekaweapons/recipe/module_drawspeed_unit.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:module_drawspeed_unit"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:module_drawspeed_unit"

--- a/src/main/resources/data/mekaweapons/recipe/module_gravity_dampener_unit.json
+++ b/src/main/resources/data/mekaweapons/recipe/module_gravity_dampener_unit.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "mekaweapons:module_gravitydampener_unit"
+    }
+  ],
   "type":"minecraft:crafting_shaped",
   "result":{
     "id":"mekaweapons:module_gravitydampener_unit"


### PR DESCRIPTION
I added conditions to each recipe, so you can disable any item without causing errors, trivially an `item_exist` for each recipe, should definitely solve #19 and the side effects of #8

[neoforge 1.21.1 docs](https://docs.neoforged.net/docs/1.21.1/resources/server/conditions)